### PR TITLE
Layout component

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "axios": "^0.19.2",
+    "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-router-dom": "^5.1.2",

--- a/src/App.js
+++ b/src/App.js
@@ -4,17 +4,20 @@ import Home from './Views/Home';
 import Profile from './Views/Profile';
 import Login from './Views/Login';
 import './App.css';
+import Layout from './Components/Layout';
 
 function App() {
   return (
     <div>
       <Router>
         <div>
-          <Switch>
-            <Route exact path="/" component={Home} />
-            <Route exact path="/profile" component={Profile} />
-            <Route exact path="/login" component={Login} />
-          </Switch>
+          <Layout>
+            <Switch>
+              <Route exact path="/" component={Home} />
+              <Route exact path="/profile" component={Profile} />
+              <Route exact path="/login" component={Login} />
+            </Switch>
+          </Layout>
         </div>
       </Router>
     </div>

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -21,7 +21,7 @@ class Header extends Component {
         <Menu.Item name="profile" link as={Link} to="/profile">
           Profile
         </Menu.Item>
-        <Menu.Item name="sign-in" link as={Link} to="/sign-in">
+        <Menu.Item name="sign-in" link as={Link} to="/login">
           Sign in
         </Menu.Item>
       </Menu>

--- a/src/Components/Layout.js
+++ b/src/Components/Layout.js
@@ -1,4 +1,6 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Header from './Header';
 
 class Layout extends Component {
   constructor(props) {
@@ -8,8 +10,20 @@ class Layout extends Component {
   }
 
   render() {
-    return <div />;
+    const { children } = this.props;
+    return (
+      <div>
+        <Header />
+        <div>
+          <main>{children}</main>
+        </div>
+      </div>
+    );
   }
 }
+
+Layout.propTypes = {
+  children: PropTypes.element.isRequired,
+};
 
 export default Layout;

--- a/src/Components/Layout.js
+++ b/src/Components/Layout.js
@@ -1,0 +1,15 @@
+import React, { Component } from 'react';
+
+class Layout extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {};
+  }
+
+  render() {
+    return <div />;
+  }
+}
+
+export default Layout;

--- a/src/Views/Home.js
+++ b/src/Views/Home.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { Grid, Image } from 'semantic-ui-react';
-import Header from '../Components/Header';
 import logo from '../logo.svg';
 import '../App.css';
 

--- a/src/Views/Home.js
+++ b/src/Views/Home.js
@@ -14,9 +14,6 @@ class Home extends Component {
   render() {
     return (
       <div>
-        <header>
-          <Header />
-        </header>
         {/* Top section */}
         <div style={{ border: 'solid black', padding: '2vw' }}>
           <Grid stackable columns={1}>

--- a/src/Views/Home.js
+++ b/src/Views/Home.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import { Grid, Image } from 'semantic-ui-react';
 import Header from '../Components/Header';
-import logo from './logo.svg';
-import './App.css';
+import logo from '../logo.svg';
+import '../App.css';
 
 class Home extends Component {
   constructor(props) {


### PR DESCRIPTION
Issue #12 

- Created a Layout component that includes the previously created Header for navigation and a section to render the component's children, which will be the current view component selected
- Added prop types to Layout as it is required by the linter due to the component's use of children as props
- Scrapped the footer section for now and added the Layout to App.js wrapping the Switch container so that it can change between views using routing while keeping the layout intact

References:
- **ESLint prop types** https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md
- React documentation on how to use **type-checking** for props https://reactjs.org/docs/typechecking-with-proptypes.html