### PR TITLE
Feature/40 mobile nav

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,7 @@ function App() {
       <div>
         <Router>
           <div>
-            <Layout>
+            <Layout breakpoint={767}>
               <Switch>
                 <Route exact path="/" component={Profile} />
                 <Route exact path="/login" component={Login} />

--- a/src/App.js
+++ b/src/App.js
@@ -4,21 +4,24 @@ import Profile from './Views/Profile';
 import Login from './Views/Login';
 import './App.css';
 import Layout from './Components/Layout';
+import WindowDimensionsProvider from './utils/WindowDimensionsProvider';
 
 function App() {
   return (
-    <div>
-      <Router>
-        <div>
-          <Layout>
-            <Switch>
-              <Route exact path="/" component={Profile} />
-              <Route exact path="/login" component={Login} />
-            </Switch>
-          </Layout>
-        </div>
-      </Router>
-    </div>
+    <WindowDimensionsProvider>
+      <div>
+        <Router>
+          <div>
+            <Layout>
+              <Switch>
+                <Route exact path="/" component={Profile} />
+                <Route exact path="/login" component={Login} />
+              </Switch>
+            </Layout>
+          </div>
+        </Router>
+      </div>
+    </WindowDimensionsProvider>
   );
 }
 

--- a/src/Components/Layout.js
+++ b/src/Components/Layout.js
@@ -16,15 +16,26 @@ const Layout = props => {
 
   const { children, breakpoint } = props;
   const classes = useStyles();
-  return (
-    <div>
-      {width > breakpoint ? <Header /> : <MobileHeader />}
-      {/* <Header /> */}
-      <div>
-        <main className={classes.main}>{children}</main>
-      </div>
-    </div>
-  );
+  let section;
+  if (width > breakpoint) {
+    section = (
+      <>
+        <Header />
+        <div>
+          <main className={classes.main}>{children}</main>
+        </div>
+      </>
+    );
+  } else {
+    section = (
+      <MobileHeader>
+        <div>
+          <main className={classes.main}>{children}</main>
+        </div>
+      </MobileHeader>
+    );
+  }
+  return <div>{section}</div>;
 };
 
 Layout.propTypes = {

--- a/src/Components/Layout.js
+++ b/src/Components/Layout.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { createUseStyles } from 'react-jss';
 import { useWindowDimensions } from '../utils/WindowDimensionsProvider';
 import Header from './Header';
+import MobileHeader from './MobileHeader';
 
 const useStyles = createUseStyles({
   main: {
@@ -17,7 +18,7 @@ const Layout = props => {
   const classes = useStyles();
   return (
     <div>
-      {width > breakpoint ? <Header /> : <div>Mobile Header goes here</div>}
+      {width > breakpoint ? <Header /> : <MobileHeader />}
       {/* <Header /> */}
       <div>
         <main className={classes.main}>{children}</main>

--- a/src/Components/Layout.js
+++ b/src/Components/Layout.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { createUseStyles } from 'react-jss';
+import { useWindowDimensions } from '../utils/WindowDimensionsProvider';
 import Header from './Header';
 
 const useStyles = createUseStyles({
@@ -10,11 +11,14 @@ const useStyles = createUseStyles({
 });
 
 const Layout = props => {
-  const { children } = props;
+  const { width } = useWindowDimensions();
+
+  const { children, breakpoint } = props;
   const classes = useStyles();
   return (
     <div>
-      <Header />
+      {width > breakpoint ? <Header /> : <div>Mobile Header goes here</div>}
+      {/* <Header /> */}
       <div>
         <main className={classes.main}>{children}</main>
       </div>
@@ -24,6 +28,7 @@ const Layout = props => {
 
 Layout.propTypes = {
   children: PropTypes.element.isRequired,
+  breakpoint: PropTypes.number.isRequired,
 };
 
 export default Layout;

--- a/src/Components/MobileHeader.js
+++ b/src/Components/MobileHeader.js
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 import { Menu, Sidebar, Icon } from 'semantic-ui-react';
 
-const MobileHeader = () => {
+const MobileHeader = props => {
   const [visible, setVisible] = useState();
+  const { children } = props;
 
   function handleVisible() {
     setVisible(true);
@@ -40,9 +42,14 @@ const MobileHeader = () => {
             <img src="https://react.semantic-ui.com/logo.png" alt="placeholder" />
           </Menu.Item>
         </Menu>
+        {children}
       </Sidebar.Pusher>
     </Sidebar.Pushable>
   );
+};
+
+MobileHeader.propTypes = {
+  children: PropTypes.element.isRequired,
 };
 
 export default MobileHeader;

--- a/src/Components/MobileHeader.js
+++ b/src/Components/MobileHeader.js
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import { Menu, Sidebar, Icon } from 'semantic-ui-react';
+
+const MobileHeader = () => {
+  const [visible, setVisible] = useState();
+
+  function handleVisible() {
+    setVisible(true);
+  }
+
+  return (
+    <Sidebar.Pushable>
+      <Sidebar
+        as={Menu}
+        animation="overlay"
+        icon="labeled"
+        inverted
+        onHide={() => setVisible(false)}
+        vertical
+        visible={visible}
+        width="thin"
+      >
+        <Menu.Item as="a">
+          <Icon name="home" />
+          Home
+        </Menu.Item>
+        <Menu.Item as="a">
+          <Icon name="gamepad" />
+          Games
+        </Menu.Item>
+        <Menu.Item as="a">
+          <Icon name="camera" />
+          Channels
+        </Menu.Item>
+      </Sidebar>
+
+      <Sidebar.Pusher dimmed={visible}>
+        <Menu>
+          <Menu.Item onClick={handleVisible} style={{ flexGrow: '1' }}>
+            <img src="https://react.semantic-ui.com/logo.png" alt="placeholder" />
+          </Menu.Item>
+        </Menu>
+      </Sidebar.Pusher>
+    </Sidebar.Pushable>
+  );
+};
+
+export default MobileHeader;

--- a/src/Components/MobileHeader.js
+++ b/src/Components/MobileHeader.js
@@ -23,22 +23,18 @@ const MobileHeader = props => {
         width="thin"
       >
         <Menu.Item as="a">
-          <Icon name="home" />
-          Home
+          <Icon name="user outline" />
+          Profile
         </Menu.Item>
         <Menu.Item as="a">
-          <Icon name="gamepad" />
-          Games
-        </Menu.Item>
-        <Menu.Item as="a">
-          <Icon name="camera" />
-          Channels
+          <Icon name="sign-in" />
+          Sign In
         </Menu.Item>
       </Sidebar>
 
       <Sidebar.Pusher dimmed={visible}>
         <Menu>
-          <Menu.Item onClick={handleVisible} style={{ flexGrow: '1' }}>
+          <Menu.Item onClick={handleVisible}>
             <img src="https://react.semantic-ui.com/logo.png" alt="placeholder" />
           </Menu.Item>
         </Menu>

--- a/src/utils/WindowDimensionsProvider.js
+++ b/src/utils/WindowDimensionsProvider.js
@@ -1,0 +1,34 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+
+const WindowDimensionsCtx = createContext(null);
+
+const WindowDimensionsProvider = ({ children }) => {
+  const [dimensions, setDimensions] = useState({
+    width: window.innerWidth,
+    height: window.innerHeight,
+  });
+
+  useEffect(() => {
+    const handleResize = () => {
+      setDimensions({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    };
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return <WindowDimensionsCtx.Provider value={dimensions}>{children}</WindowDimensionsCtx.Provider>;
+};
+
+WindowDimensionsProvider.propTypes = {
+  // eslint-disable-next-line react/forbid-prop-types
+  children: PropTypes.element.isRequired,
+};
+
+export default WindowDimensionsProvider;
+export const useWindowDimensions = () => useContext(WindowDimensionsCtx);

--- a/src/utils/WindowDimensionsProvider.js
+++ b/src/utils/WindowDimensionsProvider.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 


### PR DESCRIPTION
Issue #40 

Created a mobile view for the navbar included in the layout for the app. Added a context provider that takes in the window's dimensions and passes it down through the component tree by wrapping App.js

The breakpoint used for the mobile view is anything less than 767px will render the mobile menu. Layout.js was also reworked to conditionally render the views based on the provided breakpoint and current window dimensions; when in desktop view, the layout will be as before with a navbar on top and all children elements rendering below. When in mobile view the MobileHeader works a bit differently as it renders the whole Layout wrapped in a Sidebar so that the content itself can be overlayed by it and dimmed out as well.